### PR TITLE
add weekly avg to programmier.bar

### DIFF
--- a/podcasts/programmier-bar.yml
+++ b/podcasts/programmier-bar.yml
@@ -4,3 +4,6 @@ podcastIndexID: 1052362
 rssFeed: https://feeds.buzzsprout.com/176239.rss
 spotify: https://open.spotify.com/show/0ik0sXv9paTQCeThcOLCCJ
 description: Mit geballter Dev-Power nehmen Dennis, Fabi, Sebi und Jojo neue Podcastfolgen auf und werden dabei regelmäßig von Gäst:innen aus der Branche unterstützt. Taucht in unseren Deep Dives mit uns in Frameworks und Datenbanken ein, hört euch in den CTO-Specials die Erfahrungen führender Persönlichkeiten großer Unternehmen an und bleibt mit unseren News-Folgen stets am Ball in der Welt der App- und Webentwicklung.
+weekly_downloads_avg:
+  value: 8936
+  updated: "2022-08-04"


### PR DESCRIPTION
The weekly avg download count for programmier.bar podcast. (Based upon the last 30 Days of Downloads)