### PR TITLE
Create das-war-schon-kaputt.yml

### DIFF
--- a/podcasts/das-war-schon-kaputt.yml
+++ b/podcasts/das-war-schon-kaputt.yml
@@ -1,0 +1,8 @@
+name: DAS WAR SCHON KAPUTT
+website: http://www.daswarschonkaputt.tech/
+podcastIndexID: 3757620
+rssFeed: https://daswarschonkaputt.tech/feed/dwsk.xml
+spotify: https://open.spotify.com/show/5F92Db3OFLQXxdh2OIXEzI
+description: Wir sind ein Laber-Technik-Lebensweisheiten-Podcast, mit News, Retrogeschichten und gelegentlich Filmbesprechungen. Bob berichtet was er wieder mal kaputt gemacht hat und Jay erklärt warum es kaputt gegangen ist. Technik ist vergänglich, einiges setzt sich nie durch anderes gerät in Vergessenheit. In unserem Podcast erklären wir dir wie man Emails per Post versendet, Podcasts auf Kassette veröffentlicht, mit einem Raumschiff aus Knetmasse zum Mars fliegt und Linux auf einem Toaster installiert. Außerdem sprechen wir über die Dinge die die Technikwelt gerade bewegen. Klingt abgedreht? Ist es auch. Hör rein dann verpasst du nichts.
+tags:
+  - Technews, Linux, Darknet, Retro-Tech

--- a/podcasts/das-war-schon-kaputt.yml
+++ b/podcasts/das-war-schon-kaputt.yml
@@ -5,4 +5,7 @@ rssFeed: https://daswarschonkaputt.tech/feed/dwsk.xml
 spotify: https://open.spotify.com/show/5F92Db3OFLQXxdh2OIXEzI
 description: Wir sind ein Laber-Technik-Lebensweisheiten-Podcast, mit News, Retrogeschichten und gelegentlich Filmbesprechungen. Bob berichtet was er wieder mal kaputt gemacht hat und Jay erklärt warum es kaputt gegangen ist. Technik ist vergänglich, einiges setzt sich nie durch anderes gerät in Vergessenheit. In unserem Podcast erklären wir dir wie man Emails per Post versendet, Podcasts auf Kassette veröffentlicht, mit einem Raumschiff aus Knetmasse zum Mars fliegt und Linux auf einem Toaster installiert. Außerdem sprechen wir über die Dinge die die Technikwelt gerade bewegen. Klingt abgedreht? Ist es auch. Hör rein dann verpasst du nichts.
 tags:
-  - Technews, Linux, Darknet, Retro-Tech
+  - Technews
+  - Linux
+  - Darknet
+  - Retro-Tech


### PR DESCRIPTION
name: DAS WAR SCHON KAPUTT
website: http://www.daswarschonkaputt.tech/
podcastIndexID: 3757620
rssFeed: https://daswarschonkaputt.tech/feed/dwsk.xml
spotify: https://open.spotify.com/show/5F92Db3OFLQXxdh2OIXEzI
description: Wir sind ein Laber-Technik-Lebensweisheiten-Podcast, mit News, Retrogeschichten und gelegentlich Filmbesprechungen. Bob berichtet was er wieder mal kaputt gemacht hat und Jay erklärt warum es kaputt gegangen ist. Technik ist vergänglich, einiges setzt sich nie durch anderes gerät in Vergessenheit. In unserem Podcast erklären wir dir wie man Emails per Post versendet, Podcasts auf Kassette veröffentlicht, mit einem Raumschiff aus Knetmasse zum Mars fliegt und Linux auf einem Toaster installiert. Außerdem sprechen wir über die Dinge die die Technikwelt gerade bewegen. Klingt abgedreht? Ist es auch. Hör rein dann verpasst du nichts.
tags:
  - Technews, Linux, Darknet, Retro-Tech