### PR TITLE
Upgrade Go from v1.18 to v1.19

### DIFF
--- a/.github/workflows/podcast-data.yml
+++ b/.github/workflows/podcast-data.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       # Caching go modules to speed up the run
       - uses: actions/cache@v3

--- a/.github/workflows/render-readme.yml
+++ b/.github/workflows/render-readme.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       # Caching go modules to speed up the run
       - uses: actions/cache@v3

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       # Caching go modules to speed up the run
       - uses: actions/cache@v3
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
 
       # Caching go modules to speed up the run
       - uses: actions/cache@v3

--- a/app/cmd/collectPodcastData.go
+++ b/app/cmd/collectPodcastData.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -76,7 +75,7 @@ func cmdCollectPodcastData(cmd *cobra.Command, args []string) error {
 	for _, f := range jsonFiles {
 		absJsonFilePath := filepath.Join(jsonDir, f.Name())
 		log.Printf("Processing file %s", absJsonFilePath)
-		jsonFileContent, err := ioutil.ReadFile(absJsonFilePath)
+		jsonFileContent, err := os.ReadFile(absJsonFilePath)
 		if err != nil {
 			return err
 		}

--- a/app/cmd/convertJsonToReadme.go
+++ b/app/cmd/convertJsonToReadme.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"html/template"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -67,7 +66,7 @@ func cmdConvertJsonToReadme(cmd *cobra.Command, args []string) error {
 	for _, f := range jsonFiles {
 		absJsonFilePath := filepath.Join(jsonDir, f.Name())
 		log.Printf("Processing file %s", absJsonFilePath)
-		jsonFileContent, err := ioutil.ReadFile(absJsonFilePath)
+		jsonFileContent, err := os.ReadFile(absJsonFilePath)
 		if err != nil {
 			return err
 		}
@@ -88,7 +87,7 @@ func cmdConvertJsonToReadme(cmd *cobra.Command, args []string) error {
 	})
 
 	log.Printf("Read template file %s from disk", readmeTemplate)
-	readmeTemplateContent, err := ioutil.ReadFile(readmeTemplate)
+	readmeTemplateContent, err := os.ReadFile(readmeTemplate)
 	if err != nil {
 		return err
 	}

--- a/app/cmd/convertYamlToJson.go
+++ b/app/cmd/convertYamlToJson.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
+	"os"
 	"path"
 	"path/filepath"
 
@@ -67,7 +67,7 @@ func cmdConvertYamlToJson(cmd *cobra.Command, args []string) error {
 	for _, f := range yamlFiles {
 		absYamlFilePath := filepath.Join(yamlDir, f.Name())
 		log.Printf("Processing file %s", absYamlFilePath)
-		yamlFileContent, err := ioutil.ReadFile(absYamlFilePath)
+		yamlFileContent, err := os.ReadFile(absYamlFilePath)
 		if err != nil {
 			return err
 		}
@@ -89,7 +89,7 @@ func cmdConvertYamlToJson(cmd *cobra.Command, args []string) error {
 			// JSON file exists.
 			// Read JSON file into Podcast Information structure
 			// and overwrite yaml information
-			jsonFileContent, err := ioutil.ReadFile(absJsonFilePath)
+			jsonFileContent, err := os.ReadFile(absJsonFilePath)
 			if err != nil {
 				return err
 			}

--- a/app/cmd/types.go
+++ b/app/cmd/types.go
@@ -46,9 +46,10 @@ func (p PodcastInformation) TagsAsList() string {
 // on when the last episode was published.
 //
 // Legend:
+//
 //	🔴 Last Episode published > 6 months ago
 //	🟡 Last Episode published something between 2 months and 6 months ago
-// 	🟢 Last Episode published within today and last 2 month
+//	🟢 Last Episode published within today and last 2 month
 func (p PodcastInformation) GetLastEpisodeStatus() string {
 	t := time.Unix(p.LatestEpisodePublished, 0)
 

--- a/app/go.mod
+++ b/app/go.mod
@@ -1,6 +1,6 @@
 module github.com/EngineeringKiosk/GermanTechPodcasts
 
-go 1.18
+go 1.19
 
 require (
 	github.com/gosimple/slug v1.12.0

--- a/app/io/directory..go
+++ b/app/io/directory..go
@@ -2,19 +2,19 @@ package io
 
 import (
 	"io/fs"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 )
 
 // GetAllFilesFromDirectory will return all files
 // inside dir which will match the file extension extension.
-func GetAllFilesFromDirectory(dir, extension string) (map[string]fs.FileInfo, error) {
-	filesInDir, err := ioutil.ReadDir(dir)
+func GetAllFilesFromDirectory(dir, extension string) (map[string]fs.DirEntry, error) {
+	filesInDir, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
 
-	files := map[string]fs.FileInfo{}
+	files := map[string]fs.DirEntry{}
 	for _, f := range filesInDir {
 		if f.IsDir() {
 			continue

--- a/app/io/file.go
+++ b/app/io/file.go
@@ -2,7 +2,7 @@ package io
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 )
 
 // WriteJSONFile will write v into absFilePath.
@@ -13,6 +13,6 @@ func WriteJSONFile(absFilePath string, v any) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(absFilePath, content, 0644)
+	err = os.WriteFile(absFilePath, content, 0644)
 	return err
 }


### PR DESCRIPTION
Including: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.  (SA1019)