### PR TITLE
Fix panic: runtime error: invalid memory address or nil pointer dereference

### DIFF
--- a/app/cmd/collectPodcastData.go
+++ b/app/cmd/collectPodcastData.go
@@ -110,11 +110,11 @@ func cmdCollectPodcastData(cmd *cobra.Command, args []string) error {
 			imageFileName := f.Name()[0:len(f.Name())-len(jsonFileExtension)] + imageFileExtension
 			absImageFilePath := filepath.Join(jsonDir, imageFolder, imageFileName)
 			log.Printf("Downloading %s into %s ...", p.Feed.Artwork, absImageFilePath)
-			resp, err := downloadFile(p.Feed.Artwork, absImageFilePath)
+			_, err = downloadFile(p.Feed.Artwork, absImageFilePath)
 			if err != nil {
 				// Sometimes we get errors like
 				// Error: Get "http://media.gamedevpodcast.de/logo_2800.png": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
-				log.Printf("Downloading %s into %s ... error: %v, status code %d", p.Feed.Artwork, absImageFilePath, err, resp.StatusCode)
+				log.Printf("Downloading %s into %s ... error: %v", p.Feed.Artwork, absImageFilePath, err)
 
 				// If we get an error, but we have a target image already
 				// (like an old one), it is better to use the old one than failing.
@@ -179,7 +179,6 @@ func downloadFile(address, fileName string) (*http.Response, error) {
 	}
 	req.Header.Set("User-Agent", defaultUserAgent)
 	response, err := client.Do(req)
-
 	if err != nil {
 		return response, err
 	}


### PR DESCRIPTION
We can't assume that the status code is part of the response in an error case. See run: https://github.com/EngineeringKiosk/GermanTechPodcasts/actions/runs/3675245809/jobs/6214430653

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x9514f1]

goroutine 1 [running]:
github.com/EngineeringKiosk/GermanTechPodcasts/cmd.cmdCollectPodcastData(0xd4dc60?, {0x9f635e?, 0x4?, 0x6?})
	/home/runner/work/GermanTechPodcasts/GermanTechPodcasts/app/cmd/collectPodcastData.go:117 +0xdf1
github.com/spf13/cobra.(*Command).execute(0xd4dc60, {0xc00006c300, 0x6, 0x6})
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:916 +0xbf5
github.com/spf13/cobra.(*Command).ExecuteC(0xd4e500)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:1044 +0x5fb
github.com/spf13/cobra.(*Command).Execute(...)
	/home/runner/go/pkg/mod/github.com/spf13/cobra@v1.6.1/command.go:968
github.com/EngineeringKiosk/GermanTechPodcasts/cmd.Execute()
	/home/runner/work/GermanTechPodcasts/GermanTechPodcasts/app/cmd/root.go:24 +0x72
main.main()
	/home/runner/work/GermanTechPodcasts/GermanTechPodcasts/app/main.go:6 +0x25
```