### PR TITLE
das-war-schon-kaputt: Update website

### DIFF
--- a/podcasts/das-war-schon-kaputt.yml
+++ b/podcasts/das-war-schon-kaputt.yml
@@ -1,5 +1,5 @@
 name: DAS WAR SCHON KAPUTT
-website: http://www.daswarschonkaputt.tech/
+website: http://daswarschonkaputt.tech/
 podcastIndexID: 3757620
 rssFeed: https://daswarschonkaputt.tech/feed/dwsk.xml
 spotify: https://open.spotify.com/show/5F92Db3OFLQXxdh2OIXEzI


### PR DESCRIPTION
The server doesn't have a certificate for the www subdomain

    openssl s_client --showcerts 'daswarschonkaputt.tech:443'
    [...]
    ---
    Server certificate
    subject=CN = daswarschonkaputt.tech
    issuer=C = US, O = Let's Encrypt, CN = R3
    ---
    [...]