### PR TITLE
cybersecurity-entschluesselt: Fix typo in title

### DIFF
--- a/podcasts/cybersecurity-entschluesselt.yml
+++ b/podcasts/cybersecurity-entschluesselt.yml
@@ -1,4 +1,4 @@
-name: "Cybersecurity entschluesselt"
+name: "Cybersecurity entschlüsselt"
 website: https://www.cybersecurity-entschluesselt.de
 podcastIndexID: 5606687
 rssFeed: https://cybersecurity-entschluesselt.de/rss.xml


### PR DESCRIPTION
Title now contains the proper umlaut instead of the latin "ue" surrogate.