### PR TITLE
Add tag statistics command for podcast analysis

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -17,6 +17,10 @@ staticcheck: ## Runs static code analyzer staticcheck
 vet: ## Runs go vet
 	go vet ./...
 
+.PHONY: tagstats
+tagstats: ## get tag stats
+	./GermanTechPodcasts tagStats --yml-directory ../podcasts/ 
+
 .PHONY: run
 run: build ## Compiles and starts the application
 	./GermanTechPodcasts

--- a/app/cmd/tagStats.go
+++ b/app/cmd/tagStats.go
@@ -1,90 +1,90 @@
 package cmd
 
 import (
-    "fmt"
-    "log"
-    "os"
-    "path/filepath"
-    "sort"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
 
-    libIO "github.com/EngineeringKiosk/GermanTechPodcasts/io"
-    "github.com/spf13/cobra"
-    "gopkg.in/yaml.v3"
+	libIO "github.com/EngineeringKiosk/GermanTechPodcasts/io"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 // tagCount holds tag name and its usage count
 type tagCount struct {
-    Tag   string
-    Count int
+	Tag   string
+	Count int
 }
 
 var tagStatsCmd = &cobra.Command{
-    Use:   "tagStats",
-    Short: "Show statistics about used tags",
-    Long:  `Analyzes all podcast YML files and shows how often each tag is used.`,
-    RunE:  cmdTagStats,
+	Use:   "tagStats",
+	Short: "Show statistics about used tags",
+	Long:  `Analyzes all podcast YML files and shows how often each tag is used.`,
+	RunE:  cmdTagStats,
 }
 
 func init() {
-    rootCmd.AddCommand(tagStatsCmd)
-    tagStatsCmd.Flags().String("yml-directory", "", "Directory containing the YML files")
-    tagStatsCmd.MarkFlagRequired("yml-directory")
+	rootCmd.AddCommand(tagStatsCmd)
+	tagStatsCmd.Flags().String("yml-directory", "", "Directory containing the YML files")
+	tagStatsCmd.MarkFlagRequired("yml-directory")
 }
 
 func cmdTagStats(cmd *cobra.Command, args []string) error {
-    ymlDir, err := cmd.Flags().GetString("yml-directory")
-    if err != nil {
-        return err
-    }
+	ymlDir, err := cmd.Flags().GetString("yml-directory")
+	if err != nil {
+		return err
+	}
 
-    // Read YML files
-    ymlFiles, err := libIO.GetAllFilesFromDirectory(ymlDir, ".yml")
-    if err != nil {
-        return err
-    }
+	// Read YML files
+	ymlFiles, err := libIO.GetAllFilesFromDirectory(ymlDir, ".yml")
+	if err != nil {
+		return err
+	}
 
-    // Map to store tag counts
-    tagCounts := make(map[string]int)
+	// Map to store tag counts
+	tagCounts := make(map[string]int)
 
-    // Process each YML file
-    for _, f := range ymlFiles {
-        absYmlFilePath := filepath.Join(ymlDir, f.Name())
-        ymlFileContent, err := os.ReadFile(absYmlFilePath)
-        if err != nil {
-            return err
-        }
+	// Process each YML file
+	for _, f := range ymlFiles {
+		absYmlFilePath := filepath.Join(ymlDir, f.Name())
+		ymlFileContent, err := os.ReadFile(absYmlFilePath)
+		if err != nil {
+			return err
+		}
 
-        podcastInfo := &PodcastInformation{}
-        err = yaml.Unmarshal(ymlFileContent, podcastInfo)
-        if err != nil {
-            return err
-        }
+		podcastInfo := &PodcastInformation{}
+		err = yaml.Unmarshal(ymlFileContent, podcastInfo)
+		if err != nil {
+			return err
+		}
 
-        // Count tags
-        for _, tag := range podcastInfo.Tags {
-            tagCounts[tag]++
-        }
-    }
+		// Count tags
+		for _, tag := range podcastInfo.Tags {
+			tagCounts[tag]++
+		}
+	}
 
-    // Convert map to slice for sorting
-    var tagStats []tagCount
-    for tag, count := range tagCounts {
-        tagStats = append(tagStats, tagCount{tag, count})
-    }
+	// Convert map to slice for sorting
+	var tagStats []tagCount
+	for tag, count := range tagCounts {
+		tagStats = append(tagStats, tagCount{tag, count})
+	}
 
-    // Sort by count descending
-    sort.Slice(tagStats, func(i, j int) bool {
-        return tagStats[i].Count > tagStats[j].Count
-    })
+	// Sort by count descending
+	sort.Slice(tagStats, func(i, j int) bool {
+		return tagStats[i].Count > tagStats[j].Count
+	})
 
-    // Output results
-    log.Printf("Found %d unique tags\n", len(tagStats))
-    fmt.Println("\nTag statistics:")
-    fmt.Println("Count\tTag")
-    fmt.Println("-----\t---")
-    for _, tc := range tagStats {
-        fmt.Printf("%5d\t%s\n", tc.Count, tc.Tag)
-    }
+	// Output results
+	log.Printf("Found %d unique tags\n", len(tagStats))
+	fmt.Println("\nTag statistics:")
+	fmt.Println("Count\tTag")
+	fmt.Println("-----\t---")
+	for _, tc := range tagStats {
+		fmt.Printf("%5d\t%s\n", tc.Count, tc.Tag)
+	}
 
-    return nil
+	return nil
 }

--- a/app/cmd/tagStats.go
+++ b/app/cmd/tagStats.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+    "fmt"
+    "log"
+    "os"
+    "path/filepath"
+    "sort"
+
+    libIO "github.com/EngineeringKiosk/GermanTechPodcasts/io"
+    "github.com/spf13/cobra"
+    "gopkg.in/yaml.v3"
+)
+
+// tagCount holds tag name and its usage count
+type tagCount struct {
+    Tag   string
+    Count int
+}
+
+var tagStatsCmd = &cobra.Command{
+    Use:   "tagStats",
+    Short: "Show statistics about used tags",
+    Long:  `Analyzes all podcast YML files and shows how often each tag is used.`,
+    RunE:  cmdTagStats,
+}
+
+func init() {
+    rootCmd.AddCommand(tagStatsCmd)
+    tagStatsCmd.Flags().String("yml-directory", "", "Directory containing the YML files")
+    tagStatsCmd.MarkFlagRequired("yml-directory")
+}
+
+func cmdTagStats(cmd *cobra.Command, args []string) error {
+    ymlDir, err := cmd.Flags().GetString("yml-directory")
+    if err != nil {
+        return err
+    }
+
+    // Read YML files
+    ymlFiles, err := libIO.GetAllFilesFromDirectory(ymlDir, ".yml")
+    if err != nil {
+        return err
+    }
+
+    // Map to store tag counts
+    tagCounts := make(map[string]int)
+
+    // Process each YML file
+    for _, f := range ymlFiles {
+        absYmlFilePath := filepath.Join(ymlDir, f.Name())
+        ymlFileContent, err := os.ReadFile(absYmlFilePath)
+        if err != nil {
+            return err
+        }
+
+        podcastInfo := &PodcastInformation{}
+        err = yaml.Unmarshal(ymlFileContent, podcastInfo)
+        if err != nil {
+            return err
+        }
+
+        // Count tags
+        for _, tag := range podcastInfo.Tags {
+            tagCounts[tag]++
+        }
+    }
+
+    // Convert map to slice for sorting
+    var tagStats []tagCount
+    for tag, count := range tagCounts {
+        tagStats = append(tagStats, tagCount{tag, count})
+    }
+
+    // Sort by count descending
+    sort.Slice(tagStats, func(i, j int) bool {
+        return tagStats[i].Count > tagStats[j].Count
+    })
+
+    // Output results
+    log.Printf("Found %d unique tags\n", len(tagStats))
+    fmt.Println("\nTag statistics:")
+    fmt.Println("Count\tTag")
+    fmt.Println("-----\t---")
+    for _, tc := range tagStats {
+        fmt.Printf("%5d\t%s\n", tc.Count, tc.Tag)
+    }
+
+    return nil
+}

--- a/app/go.mod
+++ b/app/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/gosimple/slug v1.15.0
 	github.com/spf13/cobra v1.8.1
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/app/go.sum
+++ b/app/go.sum
@@ -20,4 +20,5 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Introduce a new command to analyze podcast tags and display their usage statistics. This feature enhances the ability to understand tag distribution across podcast YML files.