### PR TITLE
Add new podcast entry for 'Frauen und Technik'

### DIFF
--- a/podcasts/frauen-und-technik.yml
+++ b/podcasts/frauen-und-technik.yml
@@ -1,0 +1,12 @@
+---
+name: "Frauen und Technik – mit Eckert und Wolfangel"
+website: https://frauen-technik.podigee.io/
+podcastIndexID: 6992238
+rssFeed: https://frauen-technik.podigee.io/feed/mp3
+spotify: https://open.spotify.com/show/3HwNHImCFF1NvNMQnN2rFR
+description: "Habt ihr diesen Spruch auch schon mal gehört – mit hochgezogenen Augenbrauen, dezentem Kopfschütteln und einem leicht genervten Ausatmen: “Frauen und Technik…”, dann seid ihr hier genau richtig. Der neue Technologie-Podcast der c't “Frauen und Technik mit Svea Eckert und Eva Wolfangel” spielt genau mit diesem Klischee, bricht es charmant auf und vermittelt dabei Wissen. Die beiden erfahrenen, freien Technologie-Journalistinnen widmen sich alle 14-Tage einem spannenden Tech-Thema und laden sich dazu inspirierende weibliche Gäste ein. Aber auch die Podcast-Hosts bringen etwas mit: investigative und spannende Recherchen, zu denen es in jeder Folge gleich zu Beginn einen kurzen Deepdive gibt."
+tags:
+  - Female host
+  - News
+  - Gesellschaft
+  - Technologie


### PR DESCRIPTION
A new podcast entry for "Frauen und Technik" has been added, including relevant details such as the website, RSS feed, and description. This update addresses issue #319.