### PR TITLE
Support .yaml suffix for podcast files

### DIFF
--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -17,5 +17,5 @@ jobs:
       - name: yaml-lint
         uses: ibiqlik/action-yamllint@v3.1.1
         with:
-          file_or_dir: podcasts/*.yml
+          file_or_dir: podcasts/*.yml podcasts/*.yaml
           config_file: .yamllint.yml

--- a/app/cmd/convertYamlToJson.go
+++ b/app/cmd/convertYamlToJson.go
@@ -53,12 +53,12 @@ func cmdConvertYamlToJson(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	log.Printf("Reading files with extension %s from directory %s", io.YAMLExtension, yamlDir)
-	yamlFiles, err := io.GetAllFilesFromDirectory(yamlDir, io.YAMLExtension)
+	log.Printf("Reading files with extensions %v from directory %s", io.GetYAMLExtensions(), yamlDir)
+	yamlFiles, err := io.GetAllFilesFromDirectoryWithExtensions(yamlDir, io.GetYAMLExtensions())
 	if err != nil {
 		return err
 	}
-	log.Printf("%d files found with extension %s in directory %s", len(yamlFiles), io.YAMLExtension, yamlDir)
+	log.Printf("%d files found with extensions %v in directory %s", len(yamlFiles), io.GetYAMLExtensions(), yamlDir)
 
 	log.Printf("Reading files with extension %s from directory %s", io.JSONExtension, jsonDir)
 	jsonFiles, err := io.GetAllFilesFromDirectory(jsonDir, io.JSONExtension)

--- a/app/cmd/tagStats.go
+++ b/app/cmd/tagStats.go
@@ -41,7 +41,7 @@ func cmdTagStats(cmd *cobra.Command, args []string) error {
 	}
 
 	// Read YML files
-	ymlFiles, err := libIO.GetAllFilesFromDirectory(ymlDir, ".yml")
+	ymlFiles, err := libIO.GetAllFilesFromDirectoryWithExtensions(ymlDir, libIO.GetYAMLExtensions())
 	if err != nil {
 		return err
 	}

--- a/app/io/extension.go
+++ b/app/io/extension.go
@@ -1,9 +1,14 @@
 package io
 
 const (
-	YAMLExtension = ".yml"
-	JSONExtension = ".json"
+	YAMLExtension    = ".yml"
+	YAMLExtensionAlt = ".yaml"
+	JSONExtension    = ".json"
 )
+
+func GetYAMLExtensions() []string {
+	return []string{YAMLExtension, YAMLExtensionAlt}
+}
 
 func GetImageExtensions() []string {
 	return []string{


### PR DESCRIPTION
## Summary
- Every consumer of `podcasts/` globbed only `.yml`, so a contributor naming their file with the spec-recommended `.yaml` suffix was silently ignored — the file was not converted to JSON, not counted in tag stats, and not linted in CI.
- Widen the glob in all four call sites: a new `io.GetYAMLExtensions()` helper, the `convertYamlToJson` and `tagStats` commands (now using `GetAllFilesFromDirectoryWithExtensions`), and the `yaml-lint` GitHub Actions workflow.
- `.yml` stays the canonical suffix; existing files are untouched.

## Test plan
- [x] `go build ./...` clean
- [x] `convertYamlToJson` reports `111 files found with extensions [.yml .yaml]` (110 `.yml` + `co-op-mode.yaml`); no diffs in `generated/`
- [x] `tagStats` runs end-to-end against `../podcasts/`
- [ ] CI: `yaml-lint` workflow passes against `podcasts/*.yml podcasts/*.yaml`
- [ ] CI: `podcast-data` workflow regenerates JSON without unexpected diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)