### PR TITLE
ci: Make auto-commit step resilient to concurrent pushes

### DIFF
--- a/.github/workflows/podcast-data.yml
+++ b/.github/workflows/podcast-data.yml
@@ -47,7 +47,9 @@ jobs:
         run: ./GermanTechPodcasts generateOpml --json-directory ../generated --opml-output ../podcasts.opml
 
       # Commit results back to repository
-      - uses: stefanzweifel/git-auto-commit-action@v7.1.0
+      - name: Commit changes
+        id: auto-commit
+        uses: stefanzweifel/git-auto-commit-action@v7.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -56,6 +58,25 @@ jobs:
           commit_user_name: "GitHub Actions Bot"
           commit_user_email: "actions@github.com"
           commit_author: "GitHub Actions Bot <actions@github.com>"
+          skip_push: true
+
+      - name: Push changes with retry
+        if: steps.auto-commit.outputs.changes_detected == 'true'
+        working-directory: ${{ github.workspace }}
+        run: |
+          max_retries=3
+          for attempt in $(seq 1 $max_retries); do
+            echo "Push attempt $attempt of $max_retries"
+            if git push origin main; then
+              echo "Push succeeded on attempt $attempt"
+              exit 0
+            fi
+            echo "Push failed, pulling with rebase and retrying..."
+            git pull --rebase origin main
+            sleep $((attempt * 2))
+          done
+          echo "Push failed after $max_retries attempts"
+          exit 1
 
       - name: Trigger webpage to sync
         uses: peter-evans/repository-dispatch@v4.0.1


### PR DESCRIPTION
## Summary

The `stefanzweifel/git-auto-commit-action` does not pull or rebase before pushing — this is a deliberate non-goal upstream (see the action's README → "Limitations & Gotchas"). When this workflow runs concurrently with other actors pushing unrelated changes to `main` (e.g. a different folder), the action's internal `git push` is rejected as non-fast-forward and the workflow fails, even though the changes do not conflict.

This PR switches the auto-commit step to `skip_push: true` and adds a small shell retry loop that does `git pull --rebase` between push attempts. The pattern is the same as the one already proven in the `EngineeringKiosk/podcast-metadata` workflows.

The new push step uses `working-directory: ${{ github.workspace }}` because the job sets a job-level `working-directory: app`, but `git push` must run at the repo root.

## Test plan

- [ ] YAML still parses (workflow file shows up correctly in the Actions tab after merge)
- [ ] On the next scheduled / dispatched run, the new "Push changes with retry" step runs only when `changes_detected == 'true'`
- [ ] The downstream `peter-evans/repository-dispatch` step still fires only after a successful commit+push

🤖 Generated with [Claude Code](https://claude.com/claude-code)