### PR TITLE
Keep collecting podcast data when a feed was removed from PodcastIndex

### DIFF
--- a/app/cmd/collectPodcastData.go
+++ b/app/cmd/collectPodcastData.go
@@ -104,6 +104,13 @@ func cmdCollectPodcastData(cmd *cobra.Command, args []string) error {
 			}
 			log.Printf("Requesting 'Podcasts.GetByFeedID' data from podcast index for feed id %d ... successful", podcastInfo.PodcastIndexID)
 
+			// Once a podcast is removed from the PodcastIndex, there is nothing left to collect.
+			// We keep the data we collected in the past instead of failing the whole run.
+			if !p.Found {
+				log.Printf("PodcastIndex has no feed for id %d anymore. Keeping the existing data of %s", podcastInfo.PodcastIndexID, absJsonFilePath)
+				continue
+			}
+
 			// Set basic podcast data
 			podcastInfo.EpisodeCount = p.Feed.EpisodeCount
 			podcastInfo.ItunesID = p.Feed.ItunesID

--- a/app/podcastindex/podcasts.go
+++ b/app/podcastindex/podcasts.go
@@ -2,6 +2,7 @@ package podcastindex
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 )
@@ -13,7 +14,33 @@ import (
 type PodcastsService service
 
 type Podcast struct {
-	Feed PodcastFeed `json:"feed,omitempty"`
+	Feed PodcastFeed
+
+	// Found reports whether the API returned a feed for the requested id.
+	// Once a feed is removed from the PodcastIndex, the API answers with
+	// an empty array ("feed": []) instead of a feed object.
+	Found bool
+}
+
+func (p *Podcast) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Feed json.RawMessage `json:"feed,omitempty"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	// "feed": [] means: No feeds match this id.
+	if len(raw.Feed) == 0 || raw.Feed[0] == '[' {
+		return nil
+	}
+
+	if err := json.Unmarshal(raw.Feed, &p.Feed); err != nil {
+		return err
+	}
+	p.Found = true
+
+	return nil
 }
 
 type PodcastFeed struct {

--- a/app/podcastindex/podcasts_test.go
+++ b/app/podcastindex/podcasts_test.go
@@ -1,0 +1,50 @@
+package podcastindex
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// The PodcastIndex API returns an empty array as feed once a feed id is unknown.
+// Decoding this must not fail, otherwise a single removed podcast breaks the whole data collection.
+func TestPodcastUnmarshalJSON_RemovedFeed(t *testing.T) {
+	body := `{"status":"true","query":{"id":"685245"},"feed":[],"description":"No feeds match this id."}`
+
+	p := new(Podcast)
+	if err := json.Unmarshal([]byte(body), p); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if p.Found {
+		t.Error("Found = true, want false")
+	}
+	if p.Feed.ID != 0 {
+		t.Errorf("Feed.ID = %d, want 0", p.Feed.ID)
+	}
+}
+
+func TestPodcastUnmarshalJSON_ExistingFeed(t *testing.T) {
+	body := `{"status":"true","query":{"id":"685245"},"feed":{"id":685245,"title":"IT@DB","artwork":"https://example.com/cover.png","itunesId":1462447493,"episodeCount":94},"description":"Found matching feed."}`
+
+	p := new(Podcast)
+	if err := json.Unmarshal([]byte(body), p); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if !p.Found {
+		t.Error("Found = false, want true")
+	}
+	if p.Feed.ID != 685245 {
+		t.Errorf("Feed.ID = %d, want 685245", p.Feed.ID)
+	}
+	if p.Feed.Title != "IT@DB" {
+		t.Errorf("Feed.Title = %q, want %q", p.Feed.Title, "IT@DB")
+	}
+	if p.Feed.Artwork != "https://example.com/cover.png" {
+		t.Errorf("Feed.Artwork = %q, want %q", p.Feed.Artwork, "https://example.com/cover.png")
+	}
+	if p.Feed.ItunesID != 1462447493 {
+		t.Errorf("Feed.ItunesID = %d, want 1462447493", p.Feed.ItunesID)
+	}
+	if p.Feed.EpisodeCount != 94 {
+		t.Errorf("Feed.EpisodeCount = %d, want 94", p.Feed.EpisodeCount)
+	}
+}


### PR DESCRIPTION
## Problem

The scheduled `Podcast data` workflow fails. [Run 29679381516](https://github.com/EngineeringKiosk/GermanTechPodcasts/actions/runs/29679381516/job/88172632671) aborted while processing `generated/it-at-db.json` (feed id 685245):

```
Error: json: cannot unmarshal array into Go struct field Podcast.feed of type podcastindex.PodcastFeed:
{"status":"true","query":{"id":"685245"},"feed":[],"description":"No feeds match this id."}
```

Once a feed is removed from the PodcastIndex, the API answers with an empty JSON **array** as `feed` instead of a feed **object**. `Podcast.Feed` is typed as a struct, so decoding fails, and `cmdCollectPodcastData` returns that error immediately. A single delisted podcast therefore stopped the remaining ~50 of 112 files from being refreshed.

IT@DB has been `archive: true` with no new episode since Aug 2025, so it having disappeared from the index is expected — it just shouldn't take the whole run down with it.

## Change

- `app/podcastindex/podcasts.go`: decode `feed` through a custom `UnmarshalJSON` that treats a leading `[` as "no feed found", and expose the outcome via a new `Podcast.Found` field.
- `app/cmd/collectPodcastData.go`: when `!p.Found`, log it and `continue`. Image download, episode retrieval and the write-back are skipped, so the existing generated JSON stays byte-identical. This follows the tolerance we already apply when a cover image download fails but an older image is on disk.

Every other error path in the loop keeps its current fail-fast behaviour.

## Verification

`go build ./...`, `go vet ./...` and `go test ./...` pass. Added `app/podcastindex/podcasts_test.go`, which decodes the exact failing payload from the run log (expects no error, `Found == false`) and a normal feed response (expects the fields populated). These are the first test files in the repo.

Not verified locally: the end-to-end run against the live API, which needs the real key/secret. Worth watching the next scheduled run — it should finish, log `PodcastIndex has no feed for id 685245 anymore`, and leave `generated/it-at-db.json` unchanged.

## Noticed, not fixed

`collectPodcastData.go:150-162`: when an image download fails but an old file exists, `DoesImageExistsOnDisk(path, true)` returns an absolute path while the sibling branch returns a bare filename. The following `filepath.Join(imageFolder, podcastImageName)` then writes a broken `images//home/runner/.../images/wp-sofa.png` into `podcastInfo.Image`. That branch was hit in this same run (wp-sofa, HTTP 423). Unrelated to this crash, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)